### PR TITLE
Anchor the turnback regex in getLrsTypeValue so invalid values throw

### DIFF
--- a/packages/wsdot-elc/spec/LrsTypeUtilsSpec.ts
+++ b/packages/wsdot-elc/spec/LrsTypeUtilsSpec.ts
@@ -1,0 +1,29 @@
+import { getLrsTypeValue, LrsType } from "../src/lrsTypeUtils";
+
+describe("getLrsTypeValue", () => {
+  it("maps recognized prefixes to the matching LrsType", () => {
+    expect(getLrsTypeValue("increase")).toBe(LrsType.INCREASE);
+    expect(getLrsTypeValue("decrease")).toBe(LrsType.DECREASE);
+    expect(getLrsTypeValue("both")).toBe(LrsType.BOTH);
+    expect(getLrsTypeValue("ramp")).toBe(LrsType.RAMP);
+    expect(getLrsTypeValue("ft")).toBe(LrsType.FT);
+    expect(getLrsTypeValue("turnback")).toBe(LrsType.TURNBACK);
+    expect(getLrsTypeValue("TB")).toBe(LrsType.TURNBACK);
+  });
+
+  it("passes through valid numeric inputs unchanged", () => {
+    expect(getLrsTypeValue(1)).toBe(1);
+    expect(getLrsTypeValue(8)).toBe(8);
+    expect(getLrsTypeValue(16)).toBe(16);
+  });
+
+  it("throws on unrecognized strings that merely contain a 't'", () => {
+    // These fall through every prefix branch but contain a 't', so the
+    // unanchored turnback test used to misclassify them as TURNBACK.
+    expect(() => getLrsTypeValue("exit")).toThrowError(/Invalid value/);
+    expect(() => getLrsTypeValue("auto")).toThrowError(/Invalid value/);
+    expect(() => getLrsTypeValue("state")).toThrowError(/Invalid value/);
+    expect(() => getLrsTypeValue("light")).toThrowError(/Invalid value/);
+    expect(() => getLrsTypeValue("nest")).toThrowError(/Invalid value/);
+  });
+});

--- a/packages/wsdot-elc/src/lrsTypeUtils.ts
+++ b/packages/wsdot-elc/src/lrsTypeUtils.ts
@@ -26,7 +26,7 @@ export function getLrsTypeValue(value: number | string): number {
       output = LrsType.RAMP;
     } else if (/^f/i.test(value)) {
       output = LrsType.FT;
-    } else if (/t/i.test(value)) {
+    } else if (/^t/i.test(value)) {
       output = LrsType.TURNBACK;
     } else {
       throw new Error(`Invalid value: ${value}`);


### PR DESCRIPTION
In getLrsTypeValue, an unrecognized string value that happens to contain a "t" anywhere gets silently treated as a turnback (LrsType.TURNBACK) instead of throwing, so inputs like "exit", "auto", or "state" return 16 rather than the documented error. The cause is that the turnback branch uses an unanchored /t/i.test(value) while the five other branches all anchor with /^i/i, /^d/i, and so on. This anchors the check to /^t/i so only values starting with "t" classify as turnback and everything else hits the existing throw.

I added a small network-free spec (LrsTypeUtilsSpec) that fails before the change and passes after: it confirms the prefix mapping and numeric passthrough still work, and that "exit"/"auto"/"state" now throw. The full package suite still passes (10 specs, 0 failures). Thanks for taking a look.